### PR TITLE
First reinvent - Expand the support to more types of env. files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,94 @@
-All credits to Brendan Ingham, original creator of this amazing hook.
 
-# @nativescript-dev/multiple-environments
+# @nativescript/multiple-environments-building
 
-This Hook is made for using multiple environments within a nativescript application.
+This Hook aims to provide a better support for building a [NativeScript](https://nativescript.org/) application with multiple environments, such as:
 
-Actually this is a copy of nativescript-dev-multiple-environments adapted to work on NS 7 CLI.
+- Easily use different `App Bundle ID` in different environments.
+- Quickly apply the `Version #` from `package.json` to the actual destinations (`Info.plist` on `iOS` and `AndroidManifest.xml` on `Android`).
+- Safely configure the **Copying** strategies to any type of files under different environments, like:
+  - Using diff. `Info.plist` or `strings.xml` to set diff. **App Name** or other configs.
+  - Having dif. `GoogleService-Info.plist` for Google services.
+- Simply generate dedicated **App Icon** image for each environment.
 
-## What it does
+> Credits to [federicorp](https://github.com/federicorp), the original creator of this amazing idea (via [@nativescript-dev/multiple-environments](https://github.com/federicorp/nativescript-dev-multiple-env)), as well as [jitendraP-ashutec](https://github.com/jitendraP-ashutec) who helped add the support to separate env. rule files for `iOS` and `Android` (via [@nativescript-dev/multiple-environments](https://github.com/jitendraP-ashutec/nativescript-dev-multiple-env)).
 
-First it changes your packageId to whatever you have stated in your `environment-rules.json`
+## Installation
 
-it also copies any files you have suffixed with the name of the environemnt for example : `App_Resources/Android/google-services.staging.json` will get copied to `App_Resources/Android/google-services.json` before building. 
+```bash
+ns plugin add @nativescript/multiple-environments-building
+```
 
-## Selecting Environment
+## How to use?
 
-Once you have a initial `environment-rules.json` file you can change between the environments using `--env.use.ENV_NAME`
+Add two **Env Rules** files into the project's root folder, and they will contain the configurations for `iOS` and `Android` separately.
 
-You can also create environment file each platform like `environment-rules.android.json` or `environment-rules.ios.json`
+- `environment-rules.ios.json` - for `iOS`.
+- `environment-rules.android.json` - for `Android`.
 
-for example for ios:
-`tns run ios --env.use.staging`
+An example **Env Rules** file looks like this:
 
-this can also be used with other --env args like:
-
-`tns run ios --bundle --env.aot --env.uglify --env.use.release`
-
-## Environments
-
-a basic environment-rules.json file is generated for you it looks like this: 
-
-```(javascript)
-
+```json
 {
-    "version": "1.0.0",
     "default": "staging",
     "extraPaths": [
-        'app/environments'
+        "environments"
     ],
+    "directCopyRules": {
+        "Info.plist":"App_Resources/iOS/Info.plist",
+    },
+    "appIconPath": "environments/app-icon/icon.png",
     "environments": [
         {
-            name: "staging",
-            packageId: "org.nativescript.appName.staging",
-            copyRules: "(.*\\.staging\\..*)"
+            "name": "staging",
+            "appBundleId": "org.nativescript.appId.staging",
+            "matchRules": "(.*\\.staging\\..*)"
         },
         {
-            name: "release",
-            packageId: "org.nativescript.appName.release",
-            copyRules: "(.*\\.release\\..*)"
+            "name": "release",
+            "appBundleId": "org.nativescript.appName.release",
+            "matchRules": "(.*\\.release\\..*)"
         }
     ]
 }
-
 ```
 
-You can tweak this however you want, and add as many environments as you like.
+With it, using `--env.use.ENV_NAME` to specify the actual environment to process while **{NS}** doing the `prepare` process. For example:
 
-ExtraPaths is Optional, but can add multiple paths within the app. these will follow the same rules for the rules. 
+```bash
+# Debug
+ns debug ios --env.use.staging
+# Build a release
+ns run ios --bundle --env.aot --env.uglify --env.use.release
+```
+
+## Environment rules
+
+The **Env Rules** file currently support the following configurations:
+
+- `default` - The default `Env. Name` to use if the `cmd` does not include `--env.use.ENV_NAME`.
+- `extraPaths` - The additional paths to check the `env.` files and do the file copy if needed. For example, adding `environments` will help choose right `environment.ts` for `Angular` to use.
+  - By default, it checks the `App_Resources` folder. And the `extraPaths` will help cover other places.
+  - The paths in `extraPaths` are relative to the `project root folder`.
+- `environments` - It defines for each environment, including:
+  - `name` - The `Env. Name`, used by `--env.use.ENV_NAME`.
+  - `appBundleId` - The target **App Bundle ID**.
+  - `matchRules` - The matching rule to help find the `source env. file` and do the file copy.
+    - For example, `(.*\\.staging\\..*)` will help locate the file `Info.staging.plist`.
+- `directCopyRules` - The **direct copying rules** conducted **AFTER** the normal file copy. Typically, it is used to help prepare the files on `iOS`.
+  - Each `pair` includes two parts: the `source filename` and the `destination path` (relative to the `project root folder`).
+  - For example: `{ "Info.plist":"App_Resources/iOS/Info.plist" }` means to copy the `Info.plist` to the `App_Resources` folder once it gets copied from its `env.` version (like `Info.dev.plist`).
+- `appIconPath` - The `file path` used for `ns resources generate icons` CMD. This is very useful when the app has diff. **App Icon** under diff. environments.
+  - Still, the `path` is relative to the `project root folder`).
+
+## Discussions
+
+### Usage of `directCopyRules`
+
+Given the case that the `ns prepare` process will add all files inside the `App_Resources/iOS` folder into the Xcode project which will include all `env. files` for other environments, the rules inside `directCopyRules` will help conduct the file copy **OUTSIDE** the `App_Resources/iOS` folder.
+
+And for `Android`, since it still can be safe to delete those `env. files` **AFTER** the `ns prepare` process, the **deletion** process is just simply added to the `after-prepare` Hook.
+
+In other words, `directCopyRules` would be probably used on `iOS` side unless you are still having some other needs for `Android`.
+
+<hr>
+<h3 align="center">Made with ❤️ for the NativeScript community</h3>

--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -1,0 +1,131 @@
+var path = require("path");
+var fs = require("fs");
+var plist = require('plist');
+
+/**
+ * `after-prepare` hook.
+ *
+ * Two tasks:
+ * - Update the `version #` based on the value inside the `package.json` file
+ * - Remove "env. based" files while making `Android` builds.
+ *      - For `iOS` build, it takes another way to handle it.
+ *
+ */
+module.exports = function($logger, $projectData, hookArgs) {
+    return new Promise(function(resolve, reject) {
+        // Try to get the platform info
+        const platformNameFromHookArgs = hookArgs && (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform));
+        const platformName = (platformNameFromHookArgs  || '').toLowerCase();
+        const projectName = $projectData.projectName;
+        $logger.info('-o[NeoEnv]o--> After "prepare" hook - updating version # on platform:', platformName);
+
+        // #region -> Update Version # <-
+        // ----------
+        // Get the Version # from `package.json` file
+        const packageJson = path.join($projectData.projectDir, 'package.json');
+        if (!fs.existsSync(packageJson)) {
+            $logger.error('-o[NeoEnv]o--x Could not locate the `package.json` file under the path:', packageJson);
+            reject();
+        }
+        const versionString = JSON.parse(fs.readFileSync(packageJson)).version;
+
+        // Build a `version # code`.
+        // - For example, version `2.3.1` will have the `number` based string - `20301`
+        const versionCodeString = parseInt(
+            versionString.split('.')
+            .map((part) => part.padStart(2, '0'))
+            .join('')
+        ).toString();
+        $logger.info(`-o[NeoEnv]o--> Updated the version "${versionString}" with the version code "${versionCodeString}"`);
+
+        /*
+            Try to update the `version` to diff. platform files.
+         */
+        const platformFolderPath = path.join($projectData.platformsDir, platformName);
+        if (platformName === 'ios') {
+            // iOS - change the file `info.plist`
+            const projectInfoPlistPath = path.join(
+                platformFolderPath,
+                `${projectName}/${projectName}-Info.plist`
+            );
+            if (fs.existsSync(projectInfoPlistPath)) {
+                let infoPlistContent = plist.parse(fs.readFileSync(projectInfoPlistPath, 'utf8'));
+
+                infoPlistContent['CFBundleShortVersionString'] = versionString;
+                infoPlistContent['CFBundleVersion'] = versionCodeString;
+
+                // Write the content back
+                fs.writeFileSync(projectInfoPlistPath, plist.build(infoPlistContent));
+            }
+        } else if (platformName === 'android') {
+            // Android - change the file `AndroidManifest.xml`
+            const projectAndroidManifestPath = path.join(platformFolderPath, 'app/src/main/AndroidManifest.xml');
+            if (fs.existsSync(projectAndroidManifestPath)) {
+                let androidManifestContent = fs.readFileSync(projectAndroidManifestPath).toString();
+
+                const versionNamePattern = /(android:versionName=")[\d.]+(")/
+                if (versionNamePattern.test(androidManifestContent)) {
+                    androidManifestContent = androidManifestContent.replace(
+                        versionNamePattern,
+                        `$1${versionString}$2`
+                    );
+                }
+
+                const versionCodePattern = /(android:versionCode=")[\d.]+(")/
+                if (versionCodePattern.test(androidManifestContent)) {
+                    androidManifestContent = androidManifestContent.replace(
+                        versionCodePattern,
+                        `$1${versionCodeString}$2`
+                    );
+                }
+
+                // Write the content back
+                fs.writeFileSync(projectAndroidManifestPath, androidManifestContent);
+            }
+        }
+
+        /*
+            Try to remove "env. based" files.
+
+            NOTES:
+            - Since on iOS, every copied file in the `prepare` process is registered within the Xcode build target,
+                which means we could not simply delete them after the `prepare`.
+            - Thus, we only do the deletion for `Android`.
+         */
+
+        // The matching pattern - it includes any `env` keyword
+        const deleteTestPattern = /.*\.(development|dev|edge|test|uat|beta|staging|release)\..*/
+
+        // The atom func to test and delete the file if matches.
+        const testForFileDeletion = (parentPath, item) => {
+            const itemPath = path.join(parentPath, item);
+            try {
+                if (fs.statSync(itemPath) && fs.statSync(itemPath).isDirectory()) {
+                    // It is a folder, loop in.
+                    fs.readdirSync(itemPath).forEach((deeperItem) => testForFileDeletion(
+                        path.join(parentPath,item),
+                        deeperItem
+                    ));
+                } else {
+                    if (deleteTestPattern.test(item)) {
+                        $logger.info('-o[NeoEnv]o--> Delete a `env.` based file:', itemPath);
+                        fs.unlinkSync(itemPath);
+                    }
+                }
+            }
+            catch (_a) { }
+        };
+
+        // Delete unneeded env. related files.
+        if (platformName === 'android') {
+            const targetFolderPath = path.join(platformFolderPath, 'app');
+            // Start to test & delete files from the `paltform` folder
+            fs.readdirSync(targetFolderPath).forEach(
+                (item) => testForFileDeletion(targetFolderPath, item)
+                );
+        }
+
+        // Finish
+        resolve();
+    });
+};

--- a/lib/before-prepare.js
+++ b/lib/before-prepare.js
@@ -1,33 +1,40 @@
 "use strict";
 const env_switcher_android_1 = require("./env-switcher.android");
 const env_switcher_ios_1 = require("./env-switcher.ios");
-const hookArgReader = (args) => {
-    if (typeof args !== 'string') {
-        return Object.keys(args)[0];
-    }
-    else {
-        return args;
-    }
-};
-module.exports = function (androidResourcesMigrationService, logger, platformsDataService, projectData, hookArgs) {
+
+const DEFAULT_ENV_NAME = 'development';
+
+module.exports = function ($logger, $platformsDataService, $projectData, hookArgs, $androidResourcesMigrationService) {
+    // Get data
     const platformName = hookArgs.prepareData.platform.toLowerCase();
-    const platformData = platformsDataService.getPlatformData(platformName, projectData);
-    let environmentName;
-    if (hookArgs && hookArgs.prepareData && hookArgs.prepareData.env && hookArgs.prepareData.env.use) {
-        environmentName = hookArgReader(hookArgs.prepareData.env.use);
+    const platformData = $platformsDataService.getPlatformData(platformName, $projectData);
+
+    // Get `env.` Info
+    let environmentName = DEFAULT_ENV_NAME;
+    /*
+        The format of `env.` info inside `prepareData` is like:
+        ```
+        {
+            ...
+            env: { use: { development: true }, hmr: undefined },
+        }
+        ```
+     */
+    if (hookArgs && hookArgs.prepareData && hookArgs.prepareData.env && typeof hookArgs.prepareData.env === 'object') {
+        // object
+        environmentName = hookArgs.prepareData.env.use && typeof hookArgs.prepareData.env.use === 'object' ? Object.keys(hookArgs.prepareData.env.use)[0] : DEFAULT_ENV_NAME;
     }
-    else {
-        environmentName = 'staging';
-    }
+
+    // Run
     let envSwitcher;
     if (platformName === "android") {
-        envSwitcher = new env_switcher_android_1.EnvSwitcherAndroid(androidResourcesMigrationService, logger, platformData, projectData, environmentName);
+        envSwitcher = new env_switcher_android_1.EnvSwitcherAndroid($logger, platformData, $projectData, environmentName, $androidResourcesMigrationService);
     }
     else if (platformName === "ios") {
-        envSwitcher = new env_switcher_ios_1.EnvSwitcherIOS(logger, platformData, projectData, environmentName);
+        envSwitcher = new env_switcher_ios_1.EnvSwitcherIOS($logger, platformData, $projectData, environmentName);
     }
     else {
-        logger.warn(`Platform '${platformName}' isn't supported: skipping environment copy... `);
+        $logger.warn(`-o[NeoEnv]o--! Platform '${platformName}' isn't supported: skipping environment copy... `);
         return;
     }
     envSwitcher.run();

--- a/lib/env-switcher.android.js
+++ b/lib/env-switcher.android.js
@@ -2,16 +2,21 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const path_1 = require("path");
 const env_switcher_common_1 = require("./env-switcher.common");
+
 class EnvSwitcherAndroid extends env_switcher_common_1.EnvSwitcherCommon {
-    constructor(androidResourcesMigrationService, logger, platformData, projectData, environmentName) {
+    constructor(logger, platformData, projectData, environmentName, androidResourcesMigrationService) {
         super(logger, platformData, projectData, environmentName);
+
+        // Check if need to get an updated "app resource" folder - if it has done the `migration`, use new path.
         this.androidResourcesMigrationService = androidResourcesMigrationService;
         if (androidResourcesMigrationService.hasMigrated(projectData.appResourcesDirectoryPath)) {
-            this.androidAppResourcesFolder = path_1.join(this.androidAppResourcesFolder, "src", "main", "res");
+            this.appResourcesFolder = path_1.join(this.appResourcesFolder, "src", "main", "res");
         }
+
     }
-    copyResources() {
-        this.copyFiles(this.androidAppResourcesFolder);
+    copyAppResources() {
+        this.detectAndCopyEnvFiles(this.appResourcesFolder);
     }
 }
+
 exports.EnvSwitcherAndroid = EnvSwitcherAndroid;

--- a/lib/env-switcher.common.js
+++ b/lib/env-switcher.common.js
@@ -1,171 +1,9 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-const path = require("path");
-const fs = require("fs");
-class EnvSwitcherCommon {
-    constructor(logger, platformData, projectData, environmentName) {
-        this.logger = logger;
-        this.platformData = platformData;
-        this.projectData = projectData;
-        this.environmentName = environmentName;
-        this.rules = this.readRules();
-        this.androidPlatformFolder = path.join(this.projectData.platformsDir, 'android');
-        this.androidAppResourcesFolder = path.join(this.projectData.appResourcesDirectoryPath, 'Android');
-        this.iosPlatformFolder = path.join(this.projectData.platformsDir, 'ios');
-        this.iosAppResourcesFolder = path.join(this.projectData.appResourcesDirectoryPath, 'iOS');
-        this.logger.info(`Using ${this.environmentName}.`);
-    }
-    get currentEnvironment() {
-        let foundRules = this.rules.environments.find(envs => envs.name === this.environmentName);
-        if (foundRules) {
-            return foundRules;
-        }
-        else {
-            this.logger.fatal("Unable to find Rules for Environment: " + this.environmentName);
-        }
-    }
-    readRules() {
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const path = require('path');
+const fs = require('fs');
+const childProcess = require('child_process');
 
-        const ruleFile = this.getProjectRules();
-        if (fs.existsSync(ruleFile)) {
-            this.logger.debug("Environment Rules found, reading contents");
-            return JSON.parse(fs.readFileSync(ruleFile).toString());
-        }
-        else {
-            this.logger.fatal("Environment Rules File does not exist, Skipping....");
-            return;
-        }
-    }
-    copyFiles(inputFolder) {
-        const matchesRules = new RegExp(this.currentEnvironment.copyRules);
-        let dirName = inputFolder.indexOf(this.projectData.$projectHelper.cachedProjectDir) < 0 ? path.join(this.projectData.$projectHelper.cachedProjectDir, inputFolder) : inputFolder;
-        const dir = fs.readdirSync(dirName);
-        const getNewFilename = function (file) {
-
-            // If file name is separated by mulitple dots then only remove environment name
-            // Like File Name en.default.staging.json
-            let fileNameParts = file.split(".");
-            let ext = fileNameParts[fileNameParts.length - 1]
-            let fileName = fileNameParts.splice(0, fileNameParts.length - 2).join(".");
-            return `${fileName}.${ext}`;
-        };
-        const testForRelease = (parentPath, file) => {
-            const filePath = path.join(parentPath, file);
-            try {
-                if (fs.statSync(filePath) && fs.statSync(filePath).isDirectory()) {
-                    fs.readdirSync(filePath).forEach((deeperItem) => testForRelease(filePath, deeperItem));
-                }
-                else {
-                    // this.logger.info('----Check file:', file);
-                    if (matchesRules.test(file)) {
-                        this.logger.info('----Use env. file:', file);
-                        const fileContents = fs.readFileSync(filePath).toString();
-                        const newFileName = getNewFilename(file);
-                        const newFilePath = path.join(parentPath, newFileName);
-                        if (!this.doesSourceMatchDestination(filePath, newFilePath)) {
-                            fs.writeFileSync(newFilePath, fileContents);
-                        }
-                        else {
-                            this.logger.debug('Not writing new file, as file that exists matches the file that it will be replaced with.');
-                        }
-                    }
-                }
-            }
-            catch (_a) { }
-        };
-        dir.forEach((file) => testForRelease(dirName, file));
-    }
-    doesSourceMatchDestination(sourcePath, destinationPath) {
-        let sourceFileContents, destinationFileContents;
-        if (fs.existsSync(sourcePath)) {
-            sourceFileContents = fs.readFileSync(sourcePath).toString();
-        }
-        else {
-            this.logger.fatal('Source File: (' + sourcePath + ') does not exist!');
-        }
-        if (fs.existsSync(destinationPath)) {
-            destinationFileContents = fs.readFileSync(destinationPath).toString();
-        }
-        else {
-            this.logger.debug('Destination File: ( ' + destinationPath + ' ) does not exist!');
-            return false;
-        }
-        return sourceFileContents === destinationFileContents;
-    }
-    changePackageId() {
-        this.logger.info(`Updating project Identifier to ${this.currentEnvironment.packageId}`);
-        const packageJSONFile = path.join(this.projectData.projectDir, 'package.json');
-        const packageJSONBackup = path.join(this.projectData.projectDir, 'package.orig.json');
-        const packageJSON = JSON.parse(fs.readFileSync(packageJSONFile).toString());
-        const gradleFile = path.resolve(this.projectData.appResourcesDirectoryPath, 'Android', 'app.gradle');
-        const gradleBackup = path.resolve(this.projectData.appResourcesDirectoryPath, 'Android', 'app.gradle.bak');
-        this.projectData.projectIdentifiers.ios = this.projectData.projectIdentifiers.android = this.currentEnvironment.packageId;
-
-        try {
-            if (fs.existsSync(gradleFile)) {
-                const currentGradleFile = fs.readFileSync(gradleFile).toString();
-                fs.writeFileSync(gradleBackup, currentGradleFile);
-                const oldApplicationId = /applicationId = "([A-Za-z]{1}[A-Za-z\d_]*\.)*[A-Za-z][A-Za-z\d_]*"/;
-                const newApplicationId = `applicationId = "${this.currentEnvironment.packageId}"`;
-                const modifiedGradleFile = currentGradleFile.replace(oldApplicationId, newApplicationId);
-                fs.writeFileSync(gradleFile, modifiedGradleFile);
-            }
-            else {
-                this.logger.info('appResourcesFile: ' + this.projectData.appResourcesDirectoryPath);
-                this.logger.info('Project File Path: ' + this.projectData.projectFilePath);
-                this.logger.fatal(`Unable to find Gradle file to replace, looked at ${gradleFile}`);
-            }
-        }
-        catch (e) {
-            throw e;
-        }
-    }
-
-  // Check if there is different file for different environment other wise return default environment-rules file
-    getProjectRules() {
-        const fileName = "environment-rules." + this.platformData.platformNameLowerCase + ".json";
-        const projectRules = path.join(this.projectData.projectDir, fileName);
-        if (fs.existsSync(projectRules)) {
-            return projectRules;
-        } else {
-            const defaultFileName = "environment-rules.json";
-            return path.join(this.projectData.projectDir, defaultFileName);
-        }
-    }
-
-    maybeCreateEnvironmentRules() {
-        const projectRules = this.getProjectRules();
-        if (!fs.existsSync(projectRules)) {
-            this.logger.info('Environment Rules file does not exist, creating a basic one now.');
-            const environmentRules = {
-                "version": "1.0.0",
-                "default": "staging",
-                "extraPaths": [
-                    "app/environments"
-                ],
-                "environments": [
-                    create_environment('staging'),
-                    create_environment('release')
-                ]
-            };
-            fs.writeFileSync(projectRules, JSON.stringify(environmentRules, null, 4));
-        }
-    }
-    copyResources() { }
-    ;
-    copyExtraFolders() {
-        this.rules.extraPaths.forEach((filePath) => {
-            this.copyFiles(filePath);
-        });
-    }
-    run() {
-        this.maybeCreateEnvironmentRules();
-        this.changePackageId();
-        this.copyResources();
-        this.copyExtraFolders();
-    }
-}
-exports.EnvSwitcherCommon = EnvSwitcherCommon;
 function create_environment(versionName) {
     return {
         name: versionName,
@@ -173,3 +11,283 @@ function create_environment(versionName) {
         copyRules: `(.*\\.${versionName}\\..*)`
     };
 }
+
+class EnvSwitcherCommon {
+    constructor(logger, platformData, projectData, environmentName) {
+        this.logger = logger;
+        this.environmentName = environmentName;
+        this.logger.info(`-o[NeoEnv]o--> Using env: ${this.environmentName}`);
+
+        this.platformData = platformData;
+        this.projectData = projectData;
+        this.projectDir = this.projectData.projectDir;
+        this.platformFolder = path.join(this.projectData.platformsDir, this.platformData.platformNameLowerCase);
+        this.appResourcesFolder = path.join(this.projectData.appResourcesDirectoryPath, this.platformData.normalizedPlatformName);
+
+        this.rules = this.readRules();
+        this.directCopyRules = this.rules.directCopyRules || {};
+    }
+
+    // #region -> Rules <-
+    // ----------
+    getProjectRulesFile() {
+        const fileName = 'environment-rules.' + this.platformData.platformNameLowerCase + '.json';
+        const projectRules = path.join(this.projectData.projectDir, fileName);
+        if (fs.existsSync(projectRules)) {
+            return projectRules;
+        } else {
+            // Default file - 'environment-rules.json'
+            return path.join(this.projectData.projectDir, 'environment-rules.json');
+        }
+    }
+
+    readRules() {
+        const ruleFile = this.getProjectRulesFile();
+        if (fs.existsSync(ruleFile)) {
+            this.logger.debug('-o[NeoEnv]o--> Environment Rules found, reading contents');
+            return JSON.parse(fs.readFileSync(ruleFile).toString());
+        }
+        else {
+            this.logger.info('-o[NeoEnv]o--x "Environment Rules" file does not exist, creating a default one');
+            const environmentRules = {
+                'default': 'staging',
+                'extraPaths': [
+                    'environments'
+                ],
+                'environments': [
+                    create_environment('staging'),
+                    create_environment('release')
+                ]
+            };
+            fs.writeFileSync(ruleFile, JSON.stringify(environmentRules, null, 4));
+            return environmentRules;
+        }
+    }
+
+    // ----------
+    // #endregion
+
+    // ///////////////////////////
+
+    // #region -> Env. <-
+    // ----------
+
+    get currentEnvironment() {
+        let foundRules = this.rules.environments.find(envs => envs.name === this.environmentName);
+        if (foundRules) {
+            return foundRules;
+        }
+        else {
+            this.logger.fatal('-o[NeoEnv]o--x Unable to find Rules for Environment: ' + this.environmentName);
+        }
+    }
+
+    // ----------
+    // #endregion
+
+    // ///////////////////////////
+
+    // #region -> App Bundle ID <-
+    // ----------
+
+    /**
+     * Update App Bundle ID if needed.
+     *
+     * It reads the `App Bundle ID` from the `env. rules` file and update to the app resource files if need.
+     *
+     * NOTES:
+     * - Only need to do so on `Android`.
+     *
+     */
+    updateAppBundleId() {
+        this.logger.info(`-o[NeoEnv]o--> Updating App Bundle ID to: ${this.currentEnvironment.appBundleId}`);
+        this.projectData.projectIdentifiers.ios = this.projectData.projectIdentifiers.android = this.currentEnvironment.appBundleId;
+
+        if (this.platformData.platformNameLowerCase === 'android') {
+            const gradleFile = path.resolve(this.appResourcesFolder, 'app.gradle');
+
+            try {
+                if (fs.existsSync(gradleFile)) {
+                    const currentGradleFile = fs.readFileSync(gradleFile).toString();
+                    const oldApplicationId = /applicationId = '([A-Za-z]{1}[A-Za-z\d_]*\.)*[A-Za-z][A-Za-z\d_]*'/;
+                    const newApplicationId = `applicationId = '${this.currentEnvironment.appBundleId}'`;
+                    const modifiedGradleFile = currentGradleFile.replace(oldApplicationId, newApplicationId);
+
+                    fs.writeFileSync(gradleFile, modifiedGradleFile);
+                }
+                else {
+                    this.logger.fatal(`-o[NeoEnv]o--x Unable to find "Gradle" file to replace, @ ${gradleFile}`);
+                }
+            }
+            catch (e) {
+                throw e;
+            }
+        }
+    }
+
+    // ----------
+    // #endregion
+
+    // ///////////////////////////
+
+    // #region -> Copy Files <-
+    // ----------
+
+    // Copy files under `App_Resources` folder.
+    //  - Called on the specific platform.
+    copyAppResources() { }
+
+    copyExtraFolders() {
+        this.rules.extraPaths.forEach((filePath) => {
+            this.detectAndCopyEnvFiles(filePath);
+        });
+    }
+
+    /**
+     * Check if need to make a "direct copy" of a file.
+     *
+     * NOTES:
+     * - Usually it happens when copying a file into the `iOS` folder to
+     *      avoid leaving all unneeded `env.` files into the `iOS` app builds.
+     */
+    doDirectFileCopy(filename, filePath) {
+        if (Object.keys(this.directCopyRules).includes(filename)) {
+            const destinationFilePath = path.join(this.projectDir, this.directCopyRules[filename]);
+            this.logger.info(`-o[NeoEnv]o--> Direct copying a file "${filename}" to "${this.directCopyRules[filename]}"`);
+            fs.writeFileSync(destinationFilePath, fs.readFileSync(filePath));
+        }
+    }
+
+    detectAndCopyEnvFiles(inputFolder) {
+        const matchRules = new RegExp(this.currentEnvironment.matchRules);
+
+        // For `extraPaths` items, it is not a full path. Need to add the "base path" of the project.
+        let folderFullPath = inputFolder.indexOf(this.projectData.$projectHelper.cachedProjectDir) < 0 ?
+            path.join(this.projectData.$projectHelper.cachedProjectDir, inputFolder) : inputFolder;
+        const dirContents = fs.readdirSync(folderFullPath);
+
+        /**
+         * Build the destination filename.
+         *
+         * Based on the rules, it only remove the `env.` related section.
+         * For example: `en.default.staging.json` will be renamed to `en.default.json`
+         *
+         */
+        const buildDestinationFileName = (file) => {
+            let fileNameParts = file.split('.');
+            let ext = fileNameParts[fileNameParts.length - 1]
+            let fileName = fileNameParts.splice(0, fileNameParts.length - 2).join('.');
+            return `${fileName}.${ext}`;
+        };
+
+        const testEnvFileToCopy = (parentPath, file) => {
+            const filePath = path.join(parentPath, file);
+
+            try {
+                if (fs.statSync(filePath) && fs.statSync(filePath).isDirectory()) {
+                    // Loop into the folder.
+                    fs.readdirSync(filePath).forEach((deeperItem) => testEnvFileToCopy(filePath, deeperItem));
+                }
+                else {
+                    this.logger.debug('-o[NeoEnv]o--- Check file:', file);
+                    if (matchRules.test(file)) {
+                        const destinationFileName = buildDestinationFileName(file);
+                        const destinationFilePath = path.join(parentPath, destinationFileName);
+
+                        this.logger.info(`-o[NeoEnv]o--> Copying env. file "${file}" to "${destinationFileName}"`);
+
+                        // Check if the dest. file is the same as the source file.
+                        //  - If `yes`, skip the copy.
+                        if (!this.doesSourceMatchDestination(filePath, destinationFilePath)) {
+                            fs.writeFileSync(destinationFilePath, fs.readFileSync(filePath));
+                        }
+                        else {
+                            this.logger.debug('-o[NeoEnv]o--x Not writing new file, as file that exists matches the file that it will be replaced with.');
+                        }
+
+                        // Check if need to do a "direct file copy"
+                        this.doDirectFileCopy(destinationFileName, destinationFilePath);
+                    }
+                }
+            }
+            catch (_error) { }
+        };
+
+        // Start to check and copy files.
+        dirContents.forEach((file) => testEnvFileToCopy(folderFullPath, file));
+    }
+
+    doesSourceMatchDestination(sourcePath, destinationPath) {
+        let sourceFileContents, destinationFileContents;
+
+        if (fs.existsSync(sourcePath)) {
+            sourceFileContents = fs.readFileSync(sourcePath);
+        }
+        else {
+            this.logger.fatal(`-o[NeoEnv]o--x Source file "${sourcePath}" does not exist!`);
+        }
+
+        if (fs.existsSync(destinationPath)) {
+            destinationFileContents = fs.readFileSync(destinationPath);
+        }
+        else {
+            this.logger.debug(`-o[NeoEnv]o--x Destination file "${destinationPath}" does not exist!`);
+            return false;
+        }
+
+        return sourceFileContents === destinationFileContents;
+    }
+
+    // ----------
+    // #endregion
+
+    // ///////////////////////////
+
+    // #region -> Generate App Icon <-
+    // ----------
+
+    generateAppIcon() {
+        const appIconPath = this.rules.appIconPath;
+        if (appIconPath && fs.existsSync(path.join(this.projectDir, appIconPath))) {
+            // Get the absolute path of the app icon file, based on the `project root directory`.
+            const fullAppIconPath = path.join(this.projectDir, appIconPath);
+
+            // Run CMD
+            this.logger.info(`-o[NeoEnv]o--> Found "App Icon" path at "${appIconPath}". Re-generating...`);
+            const cmd = `ns resources generate icons ${fullAppIconPath}`
+            try {
+                childProcess.execSync(cmd, { stdio: 'ignore'})
+                this.logger.info(`-o[NeoEnv]o--> Done generating app icon`);
+            } catch (error) {
+                this.logger.fatal(`-o[NeoEnv]o--x Error in generating app icon: ${error}`);
+            }
+        }
+    }
+
+    // ----------
+    // #endregion
+
+    // ///////////////////////////
+
+    // #region -> Run <-
+    // ----------
+
+    run() {
+        this.updateAppBundleId();
+
+        // Copy Env. files
+        this.copyAppResources();
+        this.copyExtraFolders();
+
+        // Generate App Icons
+        this.generateAppIcon();
+    }
+
+    // ----------
+    // #endregion
+
+    // ///////////////////////////
+}
+
+exports.EnvSwitcherCommon = EnvSwitcherCommon;
+

--- a/lib/env-switcher.common.js
+++ b/lib/env-switcher.common.js
@@ -49,18 +49,19 @@ class EnvSwitcherCommon {
             let fileName = fileNameParts.splice(0, fileNameParts.length - 2).join(".");
             return `${fileName}.${ext}`;
         };
-        const testForRelease = file => {
-            const filePath = path.join(inputFolder, file);
+        const testForRelease = (parentPath, file) => {
+            const filePath = path.join(parentPath, file);
             try {
-                const stat = fs.statSync(filePath);
-                if (stat.isDirectory()) {
-                    fs.readdirSync(filePath).forEach(testForRelease);
+                if (fs.statSync(filePath) && fs.statSync(filePath).isDirectory()) {
+                    fs.readdirSync(filePath).forEach((deeperItem) => testForRelease(filePath, deeperItem));
                 }
                 else {
+                    // this.logger.info('----Check file:', file);
                     if (matchesRules.test(file)) {
+                        this.logger.info('----Use env. file:', file);
                         const fileContents = fs.readFileSync(filePath).toString();
                         const newFileName = getNewFilename(file);
-                        const newFilePath = path.join(inputFolder, newFileName);
+                        const newFilePath = path.join(parentPath, newFileName);
                         if (!this.doesSourceMatchDestination(filePath, newFilePath)) {
                             fs.writeFileSync(newFilePath, fileContents);
                         }
@@ -72,7 +73,7 @@ class EnvSwitcherCommon {
             }
             catch (_a) { }
         };
-        dir.forEach(testForRelease);
+        dir.forEach((file) => testForRelease(dirName, file));
     }
     doesSourceMatchDestination(sourcePath, destinationPath) {
         let sourceFileContents, destinationFileContents;

--- a/lib/env-switcher.ios.js
+++ b/lib/env-switcher.ios.js
@@ -1,9 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const env_switcher_common_1 = require("./env-switcher.common");
+
 class EnvSwitcherIOS extends env_switcher_common_1.EnvSwitcherCommon {
-    copyResources() {
-        this.copyFiles(this.iosAppResourcesFolder);
+    copyAppResources() {
+        this.detectAndCopyEnvFiles(this.appResourcesFolder);
     }
 }
+
 exports.EnvSwitcherIOS = EnvSwitcherIOS;

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@nativescript-dev/multiple-environments",
-  "version": "1.0.0",
-  "description": "A Hook For Nativescript to allow multiple Environments",
+  "name": "@nativescript/multiple-environments-building",
+  "version": "0.6.6",
+  "description": "A better solution to make Nativescript to support multiple environments during the building process.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/federicorp/nativescript-dev-multiple-env.git"
+    "url": "git+https://github.com/cowfox/nativescript-multiple-environments-building.git"
   },
   "nativescript": {
     "hooks": [
@@ -12,27 +12,30 @@
         "type": "before-prepare",
         "script": "lib/before-prepare.js",
         "inject": true
+      },
+      {
+        "type": "after-prepare",
+        "script": "lib/after-prepare.js",
+        "inject": true
       }
     ]
   },
-  "author": "Federicorp <fede_r@live.com>",
+  "author": "cowfox <foxshee@gmail.com>",
   "license": "Apache-2.0",
   "scripts": {
     "test": "exit 0;",
     "postinstall": "node postinstall.js",
-    "preuninstall": "node preuninstall.js",
-    "prepare.package": "cd ../publish && ./pack.sh",
-    "prepare.demo.install": "cd ../demo && tns plugin install ../publish/package/*.tgz",
-    "prepare.demo": " npm run prepare.package && npm run prepare.demo.install"
+    "preuninstall": "node preuninstall.js"
   },
   "devDependencies": {
-    "@types/node": "^10.7.0",
-    "@nativescript/hook": "^2.0.0"
+    "@types/node": "^12.22.12",
+    "@nativescript/hook": "^2.0.0",
+    "plist": "^3.0.6"
   },
   "bugs": {
-    "url": "https://github.com/federicorp/nativescript-dev-multiple-env/issues"
+    "url": "https://github.com/cowfox/nativescript-multiple-environments-building/issues"
   },
-  "homepage": "https://github.com/federicorp/nativescript-dev-multiple-env#readme",
+  "homepage": "https://github.com/cowfox/nativescript-multiple-environments-building#readme",
   "main": "postinstall.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
- Add after-prepare Hook to apply version # to the target building files as well as delete unneeded env. files on Android.
- Add new setting directCopyRules to help solved the issue that it could not delete unneeded env. files on iOS.
- Add new setting appIconPath to add support to manage diff. App Icon for each env.